### PR TITLE
Redirect users to ticket list after creation

### DIFF
--- a/src/Controllers/CategoryTicketController.php
+++ b/src/Controllers/CategoryTicketController.php
@@ -44,6 +44,6 @@ class CategoryTicketController extends Controller
             rescue(fn () => $ticket->createCreatedDiscordWebhook()->send($webhookUrl));
         }
 
-        return to_route('support.tickets.show', $ticket);
+        return to_route('support.tickets.index');
     }
 }


### PR DESCRIPTION
## Summary
- Redirect new support tickets to the ticket list page instead of the individual ticket view

## Testing
- `php -l src/Controllers/CategoryTicketController.php`
- `composer validate --no-check-publish`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc8fc1248324846bbd447145f15e