### PR TITLE
Limit Discord embed fields to 1000 chars

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -82,7 +82,10 @@ class Comment extends Model
             ->author($this->author->name, null, $this->author->getAvatar())
             ->addField(trans('support::messages.fields.ticket'), $this->ticket->subject)
             ->addField(trans('messages.fields.category'), $this->ticket->category->name)
-            ->addField(trans('messages.fields.content'), Str::limit($this->content, 1995))
+            ->addField(
+                trans('messages.fields.content'),
+                Str::limit($this->content, 1000)
+            )
             ->url(route('support.admin.tickets.show', $this->ticket))
             ->color('#004de6')
             ->footer('Azuriom v'.Azuriom::version())

--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -132,7 +132,10 @@ class Ticket extends Model
             ->author($this->author->name, null, $this->author->getAvatar())
             ->addField(trans('messages.fields.title'), $this->subject)
             ->addField(trans('messages.fields.category'), $this->category->name)
-            ->addField(trans('messages.fields.content'), Str::limit($comment->content, 1995))
+            ->addField(
+                trans('messages.fields.content'),
+                Str::limit($comment->content, 1000)
+            )
             ->url(route('support.admin.tickets.show', $this))
             ->color('#004de6')
             ->footer('Azuriom v'.Azuriom::version())


### PR DESCRIPTION
## Summary
- Replace 1995-character webhook field limit with 1000 in ticket and comment Discord embeds

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `php -r '$text=str_repeat("a",1100); $truncated=rtrim(mb_strimwidth($text,0,1000,"","UTF-8")); echo strlen($truncated)."\n";'`


------
https://chatgpt.com/codex/tasks/task_e_688fcbe1097c8324b213517c9e427b9a