### PR TITLE
fix: handle missing ticket comments in author reply check

### DIFF
--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -92,7 +92,7 @@ class Ticket extends Model
 
     public function authorReplied(): bool
     {
-        return $this->comment->author->is($this->author);
+        return $this->comment?->author?->is($this->author) ?? false;
     }
 
     public function status(bool $authorReplies = false): string


### PR DESCRIPTION
## Summary
- avoid calling comment author when there is no comment

## Testing
- `php -l src/Models/Ticket.php`
- `composer install`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_688fd95569188324803e9e77d68fae56